### PR TITLE
Fix coordinate shifts when merging DXF

### DIFF
--- a/merge_dxf.py
+++ b/merge_dxf.py
@@ -4,6 +4,14 @@ from ezdxf.addons import Importer
 from pathlib import Path
 
 
+def _reset_insbase(doc: ezdxf.EzDxfDocument) -> None:
+    """Set INSBASE of *doc* to (0, 0, 0) to avoid automatic offsets."""
+    try:
+        doc.header["$INSBASE"] = (0, 0, 0)
+    except Exception:
+        pass
+
+
 def merge_from_folder(folder_path: str, output: str) -> None:
     """Merge all DXF files from a folder into a single output DXF."""
     folder = Path(folder_path)
@@ -35,7 +43,8 @@ def merge_from_folder(folder_path: str, output: str) -> None:
         except Exception as e:
             print(f"Failed to read {dxf_file}: {e}")
             continue
-        
+
+        _reset_insbase(doc)
         importer = Importer(doc, merged)
         importer.import_modelspace(msp)
         importer.finalize()
@@ -62,6 +71,7 @@ def merge(files, output: str) -> None:
         except Exception as e:
             print(f"Failed to read {f}: {e}")
             continue
+        _reset_insbase(doc)
         importer = Importer(doc, merged)
         importer.import_modelspace(msp)
         importer.finalize()


### PR DESCRIPTION
## Summary
- ensure merged DXF keeps original coordinates by resetting `$INSBASE`
- call helper before importing each DXF

## Testing
- `python calc_area.py` *(fails: File only has 2 columns; cannot read column 6)*

------
https://chatgpt.com/codex/tasks/task_e_6856cc4d858c832a8aa85951370163f2